### PR TITLE
fix: ResetDB script crash when running on clean database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "rural-crowdsourcing-toolkit",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/server/backend/src/scripts/ResetDB.ts
+++ b/server/backend/src/scripts/ResetDB.ts
@@ -46,7 +46,6 @@ let scriptSequence = ['recreate-tables', 'auth-bootstrap'];
   setupDbConnection();
 
   // Remove server users from keycloak
-  const allServerUsers = await BasicModel.getRecords('server_user', {});
   await KeycloakUtils.removeAllUsers();
 
   await BBPromise.mapSeries(scriptSequence, async (action) => {


### PR DESCRIPTION
## Description/Purpose

A newly created database would not have any colums by default. The script tries to access a column before it was created, this condition results in script getting crashed. Anyways, the variable which was defined was unsed, so simply removing it fixes the issue

## Stack-trace of the issue
```bash
➜  backend git:(v4-dev) ✗ node dist/scripts/ResetDB.js
2022-10-30 21:33:26 +05:30 [info]: V1 access code generator is unavailable
2022-10-30 21:33:26 +05:30 [info]: Starting reset script DB
/Users/divyansh/Documents/GitHub/rural-crowdsourcing-toolkit/server/common/node_modules/pg-protocol/dist/parser.js:287
        const message = name === 'notice' ? new messages_1.NoticeMessage(length, messageValue) : new messages_1.DatabaseError(messageValue, length, name);
                                                                                                 ^

error: select * from "server_user" - relation "server_user" does not exist
    at Parser.parseErrorMessage (/Users/divyansh/Documents/GitHub/rural-crowdsourcing-toolkit/server/common/node_modules/pg-protocol/dist/parser.js:287:98)
    at Parser.handlePacket (/Users/divyansh/Documents/GitHub/rural-crowdsourcing-toolkit/server/common/node_modules/pg-protocol/dist/parser.js:126:29)
    at Parser.parse (/Users/divyansh/Documents/GitHub/rural-crowdsourcing-toolkit/server/common/node_modules/pg-protocol/dist/parser.js:39:38)
    at Socket.<anonymous> (/Users/divyansh/Documents/GitHub/rural-crowdsourcing-toolkit/server/common/node_modules/pg-protocol/dist/index.js:11:42)
    at Socket.emit (node:events:527:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  length: 110,
  severity: 'ERROR',
  code: '42P01',
  detail: undefined,
  hint: undefined,
  position: '15',
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'parse_relation.c',
  line: '1395',
  routine: 'parserOpenTable'
}
```